### PR TITLE
Transition fixes

### DIFF
--- a/archetypes/distill.md
+++ b/archetypes/distill.md
@@ -1,6 +1,5 @@
 +++
 description = ""
-kind = ""
 thumbnail = ""
 categories = []
 tags = []

--- a/archetypes/distill.md
+++ b/archetypes/distill.md
@@ -2,6 +2,8 @@
 description = ""
 kind = ""
 thumbnail = ""
+categories = []
+tags = []
 
 [distill]
   [distill.supportFiles]

--- a/exampleSite/content/about/index.md
+++ b/exampleSite/content/about/index.md
@@ -2,8 +2,11 @@
 title = "About Hugo"
 date = "2014-04-09"
 description = "This page is about Hugo."
-kind = "info"
 thumbnail = "https://i.ytimg.com/vi/qtIqKaDlqXo/maxresdefault.jpg"
+categories = [
+  "info",
+]
+tags = []
 
 [distill]
   [distill.supportFiles]

--- a/exampleSite/content/example/index.md
+++ b/exampleSite/content/example/index.md
@@ -4,6 +4,8 @@ description = "This is a demo article."
 date = "2017-01-10"
 kind = "demo"
 thumbnail = ""
+categories = []
+tags = []
 
 [distill]
   [distill.supportFiles]

--- a/exampleSite/content/example/index.md
+++ b/exampleSite/content/example/index.md
@@ -2,9 +2,10 @@
 title = "Attention and Augmented Recurrent Neural Networks"
 description = "This is a demo article."
 date = "2017-01-10"
-kind = "demo"
 thumbnail = ""
-categories = []
+categories = [
+  "demo"
+]
 tags = []
 
 [distill]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -126,8 +126,10 @@
       <a class="post-preview" target="_blank" href="{{ .RelPermalink }}">
         <div class="metadata">
           <p class="date">{{ dateFormat "Jan 2, 2006" .Date }}</p>
-          {{ if .Params.Kind }}
-            <p class="kind">{{ .Params.Kind }}</p>
+          {{ if .Params.Categories }}
+          {{ if gt (len .Params.Categories) 0 }}
+            <p class="kind">{{ index .Params.Categories 0 }}</p>
+          {{ end }}
           {{ end }}
         </div>
         <div class="thumbnail"><img src="{{ .Params.Thumbnail }}"></div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,24 +23,21 @@
       margin-top: 5em;
     }
 
-    .l-page .pagination .page-item .page-link {
-      text-decoration: none;
-    }
-
     .l-page .pagination .page-item {
       display: inline-block;
     }
 
     .l-page .pagination .page-item .page-link {
+      text-decoration: none;
       padding: 0.1em 0.5em;
     }
 
     .l-page .pagination > :nth-child(n+3):nth-last-child(n+3) {
-      border: solid "{{ .Site.Params.color }}" 1px;
+      border: solid {{ .Site.Params.color }} 1px;
     }
 
     .l-page .pagination .page-item.active {
-      background-color: "{{ .Site.Params.color }}";
+      background-color: {{ .Site.Params.color }};
       border: none;
     }
 
@@ -129,7 +126,9 @@
       <a class="post-preview" target="_blank" href="{{ .RelPermalink }}">
         <div class="metadata">
           <p class="date">{{ dateFormat "Jan 2, 2006" .Date }}</p>
-          <p class="kind">{{ .Params.Kind }}</p>
+          {{ if .Params.Kind }}
+            <p class="kind">{{ .Params.Kind }}</p>
+          {{ end }}
         </div>
         <div class="thumbnail"><img src="{{ .Params.Thumbnail }}"></div>
         <div class="description">

--- a/layouts/partials/distill/d-front-matter.html
+++ b/layouts/partials/distill/d-front-matter.html
@@ -21,7 +21,9 @@
     ],
     "katex": {
       "delimiters": [
-        {"left": "$$", "right": "$$", "display": false}
+        {"left": "$$", "right": "$$", "display": true},
+        {"left": "\\(", "right": "\\)", "display": false},
+        {"left": "\\[", "right": "\\]", "display": true}
       ]
     }
   }</script>


### PR DESCRIPTION
* Fixes Template Color quotes in CSS
* Add categories and tags as front matter params. Use first category optionally instead of "kind"
* Update KaTeX rendering to default options